### PR TITLE
fix infinite loop when downloading  all for a track

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -57,17 +57,18 @@ export function RegisterCommands(exercismController: ExercismController, tracksT
                 const exerciseNode = exerciseNodes[i];
                 progress.report({ message: exerciseNode.id, increment: (i / exerciseNodes.length) * 100 });
 
-                if (!(exerciseNode.exercise.status & ExerciseStatus.DOWNLOADED)) {
-                  while (true) {
-                    try {
-                      await exercismController.downloadExercise(trackNode.track, exerciseNode.exercise);
-                    } catch (e) {
-                      const action = await vscode.window.showErrorMessage(String(e), "Retry", "Cancel");
-                      if (action !== "Retry") {
-                        return;
-                      }
+                while (!(exerciseNode.exercise.status & ExerciseStatus.DOWNLOADED)) {
+                  try {
+                    await exercismController.downloadExercise(trackNode.track, exerciseNode.exercise);
+                  } catch (e) {
+                    const action = await vscode.window.showErrorMessage(String(e), "Retry", "Cancel");
+                    if (action !== "Retry") {
+                      return;
                     }
-                    tracksTreeProvider.refresh(exerciseNode);
+                  }
+                  tracksTreeProvider.refresh(exerciseNode);
+                  if (exerciseNode.exercise.status) {
+                    tracksTreeProvider.view.reveal(exerciseNode);
                   }
                 }
               }


### PR DESCRIPTION
No break was built in for the loop in the "download all" functionality in a track. This also refreshes the tree view when an exercise successfully downloads.